### PR TITLE
Fix reboot variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ module "lambda_ami_backup" {
 | retention_days               | `14`           | Is the number of days you want to keep the backups for (e.g. `14`)| No     |
 | backup_schedule              | `cron(00 19 * * ? *)` | The scheduling expression. (e.g. cron(0 20 * * ? *) or rate(5 minutes) | No       |
 | cleanup_schedule             | `cron(05 19 * * ? *)` | The scheduling expression. (e.g. cron(0 20 * * ? *) or rate(5 minutes) | No       |
-| no_reboot                    | `true`         | Don't reboot the machine as part of the snapshot process | No       |
+| reboot                       | `false`         | Reboot the machine as part of the snapshot process      | No       |

--- a/ami_backup.py
+++ b/ami_backup.py
@@ -19,7 +19,7 @@ import os
 ec = boto3.client('ec2')
 ec2_instance_id = os.environ['instance_id']
 label_id = os.environ['label_id']
-no_reboot = os.environ['no_reboot']
+no_reboot = os.environ['reboot'] == '0'
 
 def lambda_handler(event, context):
     try:
@@ -31,7 +31,7 @@ def lambda_handler(event, context):
     AMIid = ec.create_image(InstanceId=ec2_instance_id,
                             Name=label_id + "-" + ec2_instance_id + "-" + create_fmt,
                             Description=label_id + "-" + ec2_instance_id + "-" + create_fmt,
-                            NoReboot=no_reboot.lower() == 'true', DryRun=False)
+                            NoReboot=no_reboot, DryRun=False)
 
     print("Retaining AMI %s of instance %s for %d days" % (
         AMIid['ImageId'],

--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,7 @@ resource "aws_lambda_function" "ami_backup" {
       instance_id = "${var.instance_id}"
       retention   = "${var.retention_days}"
       label_id    = "${module.label.id}"
-      no_reboot   = "${var.no_reboot}"
+      reboot      = "${var.reboot ? "1" : "0"}"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,7 @@ resource "aws_lambda_function" "ami_backup" {
       instance_id = "${var.instance_id}"
       retention   = "${var.retention_days}"
       label_id    = "${module.label.id}"
-      no_reboot   = "${module.no_reboot}"
+      no_reboot   = "${var.no_reboot}"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,6 @@ variable "stage" {
   default = ""
 }
 
-variable "no_reboot" {
-  default = "true"
+variable "reboot" {
+  default = "false"
 }


### PR DESCRIPTION
The latest release of this module is broken due to a simple mistake in referencing a variable. The first commit fixes it.

The second commit changes `var.no_reboot` to `var.reboot` which, in my opinion, is much easier to understand.