### PR TITLE
Add ability to include/exclude EBS volumes from AMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ the code at
 
 Include this repository as a module in your existing terraform code:
 
-
 ```
 module "lambda_ami_backup" {
   source = "git::https://github.com/cloudposse/tf_ami_backup.git?ref=tags/0.1.0"
@@ -22,6 +21,11 @@ module "lambda_ami_backup" {
   ami_owner         = "${var.ami_owner}"
   instance_id       = "${var.instance_id}"
   retention_days    = "14"
+
+  block_device_mappings = [
+    { "DeviceName" = "/dev/xvdf", "NoDevice" = "" },
+    { "DeviceName" = "/dev/xvdg", "NoDevice" = "" },
+  ]
 }
 ```
 
@@ -39,4 +43,5 @@ module "lambda_ami_backup" {
 | retention_days               | `14`           | Is the number of days you want to keep the backups for (e.g. `14`)| No     |
 | backup_schedule              | `cron(00 19 * * ? *)` | The scheduling expression. (e.g. cron(0 20 * * ? *) or rate(5 minutes) | No       |
 | cleanup_schedule             | `cron(05 19 * * ? *)` | The scheduling expression. (e.g. cron(0 20 * * ? *) or rate(5 minutes) | No       |
-| reboot                       | `false`         | Reboot the machine as part of the snapshot process      | No       |
+| reboot                       | `false`        | Reboot the machine as part of the snapshot process       | No       |
+| block_device_mappings        | `[]`           | List of block device mappings to be included/excluded from created AMIs       | No       |

--- a/README.md
+++ b/README.md
@@ -14,13 +14,29 @@ Include this repository as a module in your existing terraform code:
 module "lambda_ami_backup" {
   source = "git::https://github.com/cloudposse/tf_ami_backup.git?ref=tags/0.1.0"
 
-  name              = "${var.name}"
-  stage             = "${var.stage}"
-  namespace         = "${var.namespace}"
-  region            = "${var.region}"
-  ami_owner         = "${var.ami_owner}"
-  instance_id       = "${var.instance_id}"
-  retention_days    = "14"
+  name           = "${var.name}"
+  stage          = "${var.stage}"
+  namespace      = "${var.namespace}"
+  region         = "${var.region}"
+  ami_owner      = "${var.ami_owner}"
+  instance_id    = "${var.instance_id}"
+  retention_days = "14"
+}
+```
+
+Example on excluding some of attached EBS volumes:
+
+```
+module "lambda_ami_backup" {
+  source = "git::https://github.com/cloudposse/tf_ami_backup.git?ref=tags/0.1.0"
+
+  name           = "${var.name}"
+  stage          = "${var.stage}"
+  namespace      = "${var.namespace}"
+  region         = "${var.region}"
+  ami_owner      = "${var.ami_owner}"
+  instance_id    = "${var.instance_id}"
+  retention_days = "14"
 
   block_device_mappings = [
     { "DeviceName" = "/dev/xvdf", "NoDevice" = "" },
@@ -28,7 +44,6 @@ module "lambda_ami_backup" {
   ]
 }
 ```
-
 
 ## Variables
 
@@ -44,4 +59,4 @@ module "lambda_ami_backup" {
 | backup_schedule              | `cron(00 19 * * ? *)` | The scheduling expression. (e.g. cron(0 20 * * ? *) or rate(5 minutes) | No       |
 | cleanup_schedule             | `cron(05 19 * * ? *)` | The scheduling expression. (e.g. cron(0 20 * * ? *) or rate(5 minutes) | No       |
 | reboot                       | `false`        | Reboot the machine as part of the snapshot process       | No       |
-| block_device_mappings        | `[]`           | List of block device mappings to be included/excluded from created AMIs       | No       |
+| block_device_mappings        | `[]`           | List of block device mappings to be included/excluded from created AMIs. With default value of [], AMIs will include all attached EBS volumes. | No       |

--- a/ami_backup.py
+++ b/ami_backup.py
@@ -15,11 +15,13 @@ import datetime
 import sys
 import pprint
 import os
+import json
 
 ec = boto3.client('ec2')
 ec2_instance_id = os.environ['instance_id']
 label_id = os.environ['label_id']
 no_reboot = os.environ['reboot'] == '0'
+block_device_mappings = json.loads(str(os.environ['block_device_mappings']))
 
 def lambda_handler(event, context):
     try:
@@ -31,7 +33,8 @@ def lambda_handler(event, context):
     AMIid = ec.create_image(InstanceId=ec2_instance_id,
                             Name=label_id + "-" + ec2_instance_id + "-" + create_fmt,
                             Description=label_id + "-" + ec2_instance_id + "-" + create_fmt,
-                            NoReboot=no_reboot, DryRun=False)
+                            NoReboot=no_reboot, DryRun=False,
+                            BlockDeviceMappings=block_device_mappings)
 
     print("Retaining AMI %s of instance %s for %d days" % (
         AMIid['ImageId'],

--- a/main.tf
+++ b/main.tf
@@ -107,12 +107,13 @@ resource "aws_lambda_function" "ami_backup" {
 
   environment = {
     variables = {
-      region      = "${var.region}"
-      ami_owner   = "${var.ami_owner}"
-      instance_id = "${var.instance_id}"
-      retention   = "${var.retention_days}"
-      label_id    = "${module.label.id}"
-      reboot      = "${var.reboot ? "1" : "0"}"
+      region                = "${var.region}"
+      ami_owner             = "${var.ami_owner}"
+      instance_id           = "${var.instance_id}"
+      retention             = "${var.retention_days}"
+      label_id              = "${module.label.id}"
+      reboot                = "${var.reboot ? "1" : "0"}"
+      block_device_mappings = "${jsonencode(var.block_device_mappings)}"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,8 +21,9 @@ variable "retention_days" {}
 variable "instance_id" {}
 
 variable "block_device_mappings" {
-  type    = "list"
-  default = []
+  description = "List of block device mappings to be included/excluded from created AMIs"
+  type        = "list"
+  default     = []
 }
 
 variable "name" {

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,11 @@ variable "retention_days" {}
 
 variable "instance_id" {}
 
+variable "block_device_mappings" {
+  type    = "list"
+  default = []
+}
+
 variable "name" {
   default = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "retention_days" {}
 variable "instance_id" {}
 
 variable "block_device_mappings" {
-  description = "List of block device mappings to be included/excluded from created AMIs"
+  description = "List of block device mappings to be included/excluded from created AMIs. With default value of [], AMIs will include all attached EBS volumes "
   type        = "list"
   default     = []
 }


### PR DESCRIPTION
With `BlockDeviceMappings` you can specify the specification of each attached EBS volumes to be included/excluded from created AMI.

`block_device_mappings = [] (default)` will include all disks.

Here is an example to exclude all attached disks but keep root volume on the AMI
```
module "oracle_ami_backup" {
  source           = "../modules/tf-aws-ec2-ami-backup"
  name             = "oradb1"
  namespace        = "myproject"
  stage            = "${var.envtype}"
  region           = "${var.aws_region}"
  ami_owner        = "${data.aws_caller_identity.current.account_id}"
  instance_id      = "${element(aws_instance.oradb.*.id, 0)}"
  retention_days   = "${var.environment == "live" ? 14 : 1}"
  backup_schedule  = "cron(00 01 * * ? *)"
  cleanup_schedule = "cron(05 01 * * ? *)"

  block_device_mappings = [ 
    { "DeviceName" = "/dev/xvdf", "NoDevice" = "" },
    { "DeviceName" = "/dev/xvdg", "NoDevice" = "" },
    { "DeviceName" = "/dev/xvdh", "NoDevice" = "" },
    { "DeviceName" = "/dev/xvdi", "NoDevice" = "" },
    { "DeviceName" = "/dev/xvdj", "NoDevice" = "" },
  ]
}
```