### PR TITLE
Use relative paths for archives

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,13 +47,13 @@ data "aws_iam_policy_document" "ami_backup" {
 data "archive_file" "ami_backup" {
   type        = "zip"
   source_file = "${path.module}/ami_backup.py"
-  output_path = "${path.module}/ami_backup.zip"
+  output_path = ".terraform/terraform-aws-ec2-ami-backup/backup-${md5(file("${path.module}/ami_backup.py"))}.zip"
 }
 
 data "archive_file" "ami_cleanup" {
   type        = "zip"
   source_file = "${path.module}/ami_cleanup.py"
-  output_path = "${path.module}/ami_cleanup.zip"
+  output_path = ".terraform/terraform-aws-ec2-ami-backup/cleanup-${md5(file("${path.module}/ami_cleanup.py"))}.zip"
 }
 
 module "label" {
@@ -96,7 +96,7 @@ resource "aws_iam_role_policy" "ami_backup" {
 }
 
 resource "aws_lambda_function" "ami_backup" {
-  filename         = "${path.module}/ami_backup.zip"
+  filename         = "${data.archive_file.ami_backup.output_path}"
   function_name    = "${module.label_backup.id}"
   description      = "Automatically backup EC2 instance (create AMI)"
   role             = "${aws_iam_role.ami_backup.arn}"
@@ -119,7 +119,7 @@ resource "aws_lambda_function" "ami_backup" {
 }
 
 resource "aws_lambda_function" "ami_cleanup" {
-  filename         = "${path.module}/ami_cleanup.zip"
+  filename         = "${data.archive_file.ami_cleanup.output_path}"
   function_name    = "${module.label_cleanup.id}"
   description      = "Automatically remove AMIs that have expired (delete AMI)"
   role             = "${aws_iam_role.ami_backup.arn}"

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+locals {
+  module_relpath = "${substr(path.module, length(path.cwd) + 1, -1)}"
+}
+
 data "aws_iam_policy_document" "default" {
   statement {
     sid = ""
@@ -46,14 +50,14 @@ data "aws_iam_policy_document" "ami_backup" {
 
 data "archive_file" "ami_backup" {
   type        = "zip"
-  source_file = "${path.module}/ami_backup.py"
-  output_path = ".terraform/terraform-aws-ec2-ami-backup/backup-${md5(file("${path.module}/ami_backup.py"))}.zip"
+  source_file = "${local.module_relpath}/ami_backup.py"
+  output_path = "${local.module_relpath}/ami_backup.zip"
 }
 
 data "archive_file" "ami_cleanup" {
   type        = "zip"
-  source_file = "${path.module}/ami_cleanup.py"
-  output_path = ".terraform/terraform-aws-ec2-ami-backup/cleanup-${md5(file("${path.module}/ami_cleanup.py"))}.zip"
+  source_file = "${local.module_relpath}/ami_cleanup.py"
+  output_path = "${local.module_relpath}/ami_cleanup.zip"
 }
 
 module "label" {


### PR DESCRIPTION
## what
* Avoid using absolute paths which are not portable across workstations

## why

This fixes issues when multiple people are working on the same project and they have the project located in different places.

Before this change, we were seeing plans like:

```
  ~ module.lambda_ami_backup.aws_lambda_function.ami_backup
      filename:                    "/home/user1/some-project/terraform/workspace/management-nonprod/.terraform/modules/49890e3df5623d30b47ac70e1936d38f/ami_backup.zip" => "/Users/user2/some-project/terraform/workspace/management-nonprod/.terraform/modules/49890e3df5623d30b47ac70e1936d38f/ami_backup.zip"
```

We've tested this change and the plans are now clean.

I've used relative paths like this in other modules/projects, putting archives in the `.terraform` directory, and haven't had any issues so far. An md5 is used in the filename to avoid conflicts with multiple versions of this module being used in the same project (unlikely but it's better to be safe).